### PR TITLE
Add a way to preserve v2 releases

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,12 @@ require (
 	github.com/helm/helm-2to3 v0.6.0
 	github.com/joho/godotenv v1.3.0
 	github.com/kelseyhightower/envconfig v1.4.0
+	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.6.1
 	gopkg.in/yaml.v2 v2.2.8
 	helm.sh/helm/v3 v3.1.3
+	k8s.io/api v0.17.2
+	k8s.io/apimachinery v0.17.8
+	k8s.io/client-go v0.17.2
 	rsc.io/letsencrypt v0.0.3 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -707,11 +707,14 @@ k8s.io/apiextensions-apiserver v0.17.2/go.mod h1:4KdMpjkEjjDI2pPfBA15OscyNldHWdB
 k8s.io/apimachinery v0.17.2/go.mod h1:b9qmWdKlLuU9EBh+06BtLcSf/Mu89rWL33naRxs1uZg=
 k8s.io/apimachinery v0.17.8 h1:zXvd8rYMAjRJXpILP9tdAiUnFIENM9EmHuE81apIoms=
 k8s.io/apimachinery v0.17.8/go.mod h1:Lg8zZ5iC/O8UjCqW6DNhcQG2m4TdjF9kwG3891OWbbA=
+k8s.io/apimachinery v0.19.2 h1:5Gy9vQpAGTKHPVOh5c4plE274X8D/6cuEiTO2zve7tc=
 k8s.io/apiserver v0.17.2/go.mod h1:lBmw/TtQdtxvrTk0e2cgtOxHizXI+d0mmGQURIHQZlo=
 k8s.io/cli-runtime v0.17.2 h1:YH4txSplyGudvxjhAJeHEtXc7Tr/16clKGfN076ydGk=
 k8s.io/cli-runtime v0.17.2/go.mod h1:aa8t9ziyQdbkuizkNLAw3qe3srSyWh9zlSB7zTqRNPI=
 k8s.io/client-go v0.17.2 h1:ndIfkfXEGrNhLIgkr0+qhRguSD3u6DCmonepn1O6NYc=
 k8s.io/client-go v0.17.2/go.mod h1:QAzRgsa0C2xl4/eVpeVAZMvikCn8Nm81yqVx3Kk9XYI=
+k8s.io/client-go v1.5.1 h1:XaX/lo2/u3/pmFau8HN+sB5C/b4dc4Dmm2eXjBH4p1E=
+k8s.io/client-go v11.0.0+incompatible h1:LBbX2+lOwY9flffWlJM7f1Ct8V2SRNiMRDFeiwnJo9o=
 k8s.io/code-generator v0.17.2/go.mod h1:DVmfPQgxQENqDIzVR2ddLXMH34qeszkKSdH/N+s+38s=
 k8s.io/component-base v0.17.2 h1:0XHf+cerTvL9I5Xwn9v+0jmqzGAZI7zNydv4tL6Cw6A=
 k8s.io/component-base v0.17.2/go.mod h1:zMPW3g5aH7cHJpKYQ/ZsGMcgbsA/VyhEugF3QT1awLs=

--- a/internal/env/config.go
+++ b/internal/env/config.go
@@ -22,40 +22,40 @@ var (
 // not have the `PLUGIN_` prefix.
 type Config struct {
 	// Configuration for drone-helm itself
-	Command            string   `envconfig:"mode"`                   // Helm command to run
-	DroneEvent         string   `envconfig:"drone_build_event"`      // Drone event that invoked this plugin.
-	UpdateDependencies bool     `split_words:"true"`                 // [Deprecated] Call `helm dependency update` before the main command (deprecated, use dependencies_action: update instead)
-	DependenciesAction string   `split_words:"true"`                 // Call `helm dependency build` or `helm dependency update` before the main command
-	AddRepos           []string `split_words:"true"`                 // Call `helm repo add` before the main command
-	RepoCertificate    string   `envconfig:"repo_certificate"`       // The Helm chart repository's self-signed certificate (must be base64-encoded)
-	RepoCACertificate  string   `envconfig:"repo_ca_certificate"`    // The Helm chart repository CA's self-signed certificate (must be base64-encoded)
-	Debug              bool     ``                                   // Generate debug output and pass --debug to all helm commands
-	Values             string   ``                                   // Argument to pass to --set in applicable helm commands
-	StringValues       string   `split_words:"true"`                 // Argument to pass to --set-string in applicable helm commands
-	ValuesFiles        []string `split_words:"true"`                 // Arguments to pass to --values in applicable helm commands
-	Namespace          string   ``                                   // Kubernetes namespace for all helm commands
-	KubeToken          string   `split_words:"true"`                 // Kubernetes authentication token to put in .kube/config
-	SkipTLSVerify      bool     `envconfig:"skip_tls_verify"`        // Put insecure-skip-tls-verify in .kube/config
-	Certificate        string   `envconfig:"kube_certificate"`       // The Kubernetes cluster CA's self-signed certificate (must be base64-encoded)
-	APIServer          string   `envconfig:"kube_api_server"`        // The Kubernetes cluster's API endpoint
-	ServiceAccount     string   `envconfig:"kube_service_account"`   // Account to use for connecting to the Kubernetes cluster
-	ChartVersion       string   `split_words:"true"`                 // Specific chart version to use in `helm upgrade`
-	DryRun             bool     `split_words:"true"`                 // Pass --dry-run to applicable helm commands
-	Wait               bool     `envconfig:"wait_for_upgrade"`       // Pass --wait to applicable helm commands
-	ReuseValues        bool     `split_words:"true"`                 // Pass --reuse-values to `helm upgrade`
-	KeepHistory        bool     `split_words:"true"`                 // Pass --keep-history to `helm uninstall`
-	Timeout            string   ``                                   // Argument to pass to --timeout in applicable helm commands
-	Chart              string   ``                                   // Chart argument to use in applicable helm commands
-	Release            string   ``                                   // Release argument to use in applicable helm commands
-	Force              bool     `envconfig:"force_upgrade"`          // Pass --force to applicable helm commands
-	AtomicUpgrade      bool     `split_words:"true"`                 // Pass --atomic to `helm upgrade`
-	CleanupOnFail      bool     `envconfig:"cleanup_failed_upgrade"` // Pass --cleanup-on-fail to `helm upgrade`
-	LintStrictly       bool     `split_words:"true"`                 // Pass --strict to `helm lint`
-	EnableV2Conversion bool     `split_words:"true" default:"true"`  // Whether or not to use 2to3 convert to migrate Releases from v2 to v3
-	DeleteV2Releases   bool     `split_words:"true"`                 // Pass --delete-v2-releases option for 2to3 convert command
-	MaxReleaseVersions int      `split_words:"true"`                 // Pass --release-versions-max option for 2to3 convert command
-	TillerNS           string   `envconfig:"tiller_ns"`              // Tiller namespace (--tiller-ns) for 2to3 convert command
-	TillerLabel        string   `split_words:"true"`                 // Tiller label selector (--label) for 2to3 convert command
+	Command             string   `envconfig:"mode"`                   // Helm command to run
+	DroneEvent          string   `envconfig:"drone_build_event"`      // Drone event that invoked this plugin.
+	UpdateDependencies  bool     `split_words:"true"`                 // [Deprecated] Call `helm dependency update` before the main command (deprecated, use dependencies_action: update instead)
+	DependenciesAction  string   `split_words:"true"`                 // Call `helm dependency build` or `helm dependency update` before the main command
+	AddRepos            []string `split_words:"true"`                 // Call `helm repo add` before the main command
+	RepoCertificate     string   `envconfig:"repo_certificate"`       // The Helm chart repository's self-signed certificate (must be base64-encoded)
+	RepoCACertificate   string   `envconfig:"repo_ca_certificate"`    // The Helm chart repository CA's self-signed certificate (must be base64-encoded)
+	Debug               bool     ``                                   // Generate debug output and pass --debug to all helm commands
+	Values              string   ``                                   // Argument to pass to --set in applicable helm commands
+	StringValues        string   `split_words:"true"`                 // Argument to pass to --set-string in applicable helm commands
+	ValuesFiles         []string `split_words:"true"`                 // Arguments to pass to --values in applicable helm commands
+	Namespace           string   ``                                   // Kubernetes namespace for all helm commands
+	KubeToken           string   `split_words:"true"`                 // Kubernetes authentication token to put in .kube/config
+	SkipTLSVerify       bool     `envconfig:"skip_tls_verify"`        // Put insecure-skip-tls-verify in .kube/config
+	Certificate         string   `envconfig:"kube_certificate"`       // The Kubernetes cluster CA's self-signed certificate (must be base64-encoded)
+	APIServer           string   `envconfig:"kube_api_server"`        // The Kubernetes cluster's API endpoint
+	ServiceAccount      string   `envconfig:"kube_service_account"`   // Account to use for connecting to the Kubernetes cluster
+	ChartVersion        string   `split_words:"true"`                 // Specific chart version to use in `helm upgrade`
+	DryRun              bool     `split_words:"true"`                 // Pass --dry-run to applicable helm commands
+	Wait                bool     `envconfig:"wait_for_upgrade"`       // Pass --wait to applicable helm commands
+	ReuseValues         bool     `split_words:"true"`                 // Pass --reuse-values to `helm upgrade`
+	KeepHistory         bool     `split_words:"true"`                 // Pass --keep-history to `helm uninstall`
+	Timeout             string   ``                                   // Argument to pass to --timeout in applicable helm commands
+	Chart               string   ``                                   // Chart argument to use in applicable helm commands
+	Release             string   ``                                   // Release argument to use in applicable helm commands
+	Force               bool     `envconfig:"force_upgrade"`          // Pass --force to applicable helm commands
+	AtomicUpgrade       bool     `split_words:"true"`                 // Pass --atomic to `helm upgrade`
+	CleanupOnFail       bool     `envconfig:"cleanup_failed_upgrade"` // Pass --cleanup-on-fail to `helm upgrade`
+	LintStrictly        bool     `split_words:"true"`                 // Pass --strict to `helm lint`
+	DisableV2Conversion bool     `split_words:"true"`                 // Whether or not to use 2to3 convert to migrate Releases from v2 to v3
+	DeleteV2Releases    bool     `split_words:"true"`                 // Pass --delete-v2-releases option for 2to3 convert command
+	MaxReleaseVersions  int      `split_words:"true"`                 // Pass --release-versions-max option for 2to3 convert command
+	TillerNS            string   `envconfig:"tiller_ns"`              // Tiller namespace (--tiller-ns) for 2to3 convert command
+	TillerLabel         string   `split_words:"true"`                 // Tiller label selector (--label) for 2to3 convert command
 
 	Stdout io.Writer `ignored:"true"`
 	Stderr io.Writer `ignored:"true"`
@@ -106,7 +106,7 @@ func NewConfig(stdout, stderr io.Writer) (*Config, error) {
 	// Deprecation messages
 	cfg.varsMessage(deprecatedVars, "Warning: ignoring deprecated '%s' setting\n")
 
-	if !cfg.EnableV2Conversion && (cfg.Command != "convert") {
+	if cfg.DisableV2Conversion && (cfg.Command != "convert") {
 		cfg.varsMessage(convertVars, "Warning: ignoring '%s' setting as is only used when 'mode' is 'convert' or 'enable_v2_conversion' is 'true'\n")
 	}
 

--- a/internal/env/config.go
+++ b/internal/env/config.go
@@ -51,7 +51,7 @@ type Config struct {
 	AtomicUpgrade      bool     `split_words:"true"`                 // Pass --atomic to `helm upgrade`
 	CleanupOnFail      bool     `envconfig:"cleanup_failed_upgrade"` // Pass --cleanup-on-fail to `helm upgrade`
 	LintStrictly       bool     `split_words:"true"`                 // Pass --strict to `helm lint`
-	EnableV2Conversion bool     `split_words:"true"`                 // Whether or not to use 2to3 convert to migrate Releases from v2 to v3
+	EnableV2Conversion bool     `split_words:"true" default:"true"`  // Whether or not to use 2to3 convert to migrate Releases from v2 to v3
 	DeleteV2Releases   bool     `split_words:"true"`                 // Pass --delete-v2-releases option for 2to3 convert command
 	MaxReleaseVersions int      `split_words:"true"`                 // Pass --release-versions-max option for 2to3 convert command
 	TillerNS           string   `envconfig:"tiller_ns"`              // Tiller namespace (--tiller-ns) for 2to3 convert command

--- a/internal/helm/plan.go
+++ b/internal/helm/plan.go
@@ -3,9 +3,10 @@ package helm
 import (
 	"errors"
 	"fmt"
+	"os"
+
 	"github.com/pelotech/drone-helm3/internal/env"
 	"github.com/pelotech/drone-helm3/internal/run"
-	"os"
 )
 
 const (
@@ -96,7 +97,7 @@ var upgrade = func(cfg env.Config) []Step {
 	var steps []Step
 	steps = append(steps, run.NewInitKube(cfg, kubeConfigTemplate, kubeConfigFile))
 
-	if cfg.EnableV2Conversion {
+	if !cfg.DisableV2Conversion {
 		// The "helm" context is coming from the template
 		steps = append(steps, run.NewConvert(cfg, kubeConfigFile, "helm"))
 	}

--- a/internal/helm/plan_test.go
+++ b/internal/helm/plan_test.go
@@ -118,9 +118,10 @@ func (suite *PlanTestSuite) TestExecuteAbortsOnError() {
 
 func (suite *PlanTestSuite) TestUpgrade() {
 	steps := upgrade(env.Config{})
-	suite.Require().Equal(2, len(steps), "upgrade should return 2 steps")
+	suite.Require().Equal(3, len(steps), "upgrade should return 3 steps")
 	suite.IsType(&run.InitKube{}, steps[0])
-	suite.IsType(&run.Upgrade{}, steps[1])
+	suite.IsType(&run.Convert{}, steps[1])
+	suite.IsType(&run.Upgrade{}, steps[2])
 }
 
 func (suite *PlanTestSuite) TestUpgradeWithUpdateDependencies() {
@@ -128,9 +129,10 @@ func (suite *PlanTestSuite) TestUpgradeWithUpdateDependencies() {
 		UpdateDependencies: true,
 	}
 	steps := upgrade(cfg)
-	suite.Require().Equal(3, len(steps), "upgrade should have a third step when DepUpdate is true")
+	suite.Require().Equal(4, len(steps), "upgrade should have a third step when DepUpdate is true")
 	suite.IsType(&run.InitKube{}, steps[0])
-	suite.IsType(&run.DepUpdate{}, steps[1])
+	suite.IsType(&run.Convert{}, steps[1])
+	suite.IsType(&run.DepUpdate{}, steps[2])
 }
 
 func (suite *PlanTestSuite) TestUpgradeWithAddRepos() {
@@ -141,16 +143,16 @@ func (suite *PlanTestSuite) TestUpgradeWithAddRepos() {
 	}
 	steps := upgrade(cfg)
 	suite.Require().True(len(steps) > 1, "upgrade should generate at least two steps")
-	suite.IsType(&run.AddRepo{}, steps[1])
+	suite.IsType(&run.Convert{}, steps[1])
+	suite.IsType(&run.AddRepo{}, steps[2])
 }
 
-func (suite *PlanTestSuite) TestUpgradeWithConvert() {
-	cfg := env.Config{}
-	steps := upgrade(cfg)
-	suite.Require().Equal(3, len(steps), "upgrade should return 3 steps")
+func (suite *PlanTestSuite) TestUpgradeWithoutConvert() {
+
+	steps := upgrade(env.Config{DisableV2Conversion: true})
+	suite.Require().Equal(2, len(steps), "upgrade should return 2 steps")
 	suite.IsType(&run.InitKube{}, steps[0])
-	suite.IsType(&run.Convert{}, steps[1])
-	suite.IsType(&run.Upgrade{}, steps[2])
+	suite.IsType(&run.Upgrade{}, steps[1])
 }
 
 func (suite *PlanTestSuite) TestUninstall() {

--- a/internal/helm/plan_test.go
+++ b/internal/helm/plan_test.go
@@ -2,10 +2,11 @@ package helm
 
 import (
 	"fmt"
-	"github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/suite"
 	"strings"
 	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/suite"
 
 	"github.com/pelotech/drone-helm3/internal/env"
 	"github.com/pelotech/drone-helm3/internal/run"
@@ -144,9 +145,7 @@ func (suite *PlanTestSuite) TestUpgradeWithAddRepos() {
 }
 
 func (suite *PlanTestSuite) TestUpgradeWithConvert() {
-	cfg := env.Config{
-		EnableV2Conversion: true,
-	}
+	cfg := env.Config{}
 	steps := upgrade(cfg)
 	suite.Require().Equal(3, len(steps), "upgrade should return 3 steps")
 	suite.IsType(&run.InitKube{}, steps[0])

--- a/internal/run/convert.go
+++ b/internal/run/convert.go
@@ -73,9 +73,8 @@ func NewConvert(cfg env.Config, kubeConfig string, kubeContext string) *Convert 
 		cfg.TillerLabel = "OWNER=TILLER"
 	}
 
-	if cfg.Release != "" {
-		cfg.TillerLabel += fmt.Sprintf(",NAME=%s", cfg.Release)
-	}
+	// Build the label selector "OWNER=TILLER,NAME=myapp"
+	cfg.TillerLabel += fmt.Sprintf(",NAME=%s", cfg.Release)
 
 	convert.convertOptions = convertcmd.ConvertOptions{
 		DeleteRelease:      cfg.DeleteV2Releases,
@@ -169,7 +168,12 @@ func (c *Convert) Execute() error {
 	return nil
 }
 
-// Prepare is not used but it's required to fulfill the Step interface
+// Prepare checks required inputs
 func (c *Convert) Prepare() error {
+
+	if c.convertOptions.ReleaseName == "" {
+		return fmt.Errorf("release is required")
+	}
+
 	return nil
 }

--- a/internal/run/convert.go
+++ b/internal/run/convert.go
@@ -146,22 +146,26 @@ func (c *Convert) Execute() error {
 		Context: c.kubeContext,
 	}
 
-	clientset, err := clientsetFromFile(c.kubeConfig)
-	if err != nil {
-		return err
-	}
-
-	configmaps, err := c.getV2ReleaseConfigmaps(clientset)
-	if err != nil {
-		return err
-	}
-
-	if err := convertcmd.Convert(c.convertOptions, kc); err != nil {
-		return err
-	}
-
 	if !c.convertOptions.DeleteRelease {
+		clientset, err := clientsetFromFile(c.kubeConfig)
+		if err != nil {
+			return err
+		}
+
+		configmaps, err := c.getV2ReleaseConfigmaps(clientset)
+		if err != nil {
+			return err
+		}
+
+		if err := convertcmd.Convert(c.convertOptions, kc); err != nil {
+			return err
+		}
+
 		if err := c.preserveV2ReleaseConfigmaps(clientset, configmaps, "converted-to-helm3"); err != nil {
+			return err
+		}
+	} else {
+		if err := convertcmd.Convert(c.convertOptions, kc); err != nil {
 			return err
 		}
 	}

--- a/internal/run/convert.go
+++ b/internal/run/convert.go
@@ -80,20 +80,13 @@ func preserveV2(clientset kubernetes.Interface, o convertcmd.ConvertOptions) err
 
 	cmClient := clientset.CoreV1().ConfigMaps(o.TillerNamespace)
 
-	var updateErrors []error
-
 	log.Printf("Preserving release versions of %s", o.ReleaseName)
 	for _, item := range configMaps.Items {
 		item.Labels["OWNER"] = "none"
 
-		_, updateErr := cmClient.Update(&item)
-		if updateErr != nil {
-			updateErrors = append(updateErrors, updateErr)
+		if _, err := cmClient.Update(&item); err != nil {
+			return fmt.Errorf("Failure preserving release version %s", item.Name)
 		}
-	}
-
-	if len(updateErrors) > 0 {
-		return fmt.Errorf("Failure preserving release info of %s", o.ReleaseName)
 	}
 
 	return nil

--- a/internal/run/convert.go
+++ b/internal/run/convert.go
@@ -98,7 +98,7 @@ func NewConvert(cfg env.Config, kubeConfig string, kubeContext string) *Convert 
 	return convert
 }
 
-// getReleaseConfigmaps returns a list of configmaps that are helm v2 releases
+// getV2ReleaseConfigmaps returns a list of configmaps that are helm v2 releases
 func (c *Convert) getV2ReleaseConfigmaps(clientset kubernetes.Interface) (*corev1.ConfigMapList, error) {
 
 	return clientset.CoreV1().ConfigMaps(c.convertOptions.TillerNamespace).List(metav1.ListOptions{
@@ -106,7 +106,7 @@ func (c *Convert) getV2ReleaseConfigmaps(clientset kubernetes.Interface) (*corev
 	})
 }
 
-// preserveV2 keeps the helm v2 configmaps by modifying a label
+// preserveV2ReleaseConfigmaps keeps the helm v2 configmaps by modifying a label
 func (c *Convert) preserveV2ReleaseConfigmaps(clientset kubernetes.Interface, configmaps *corev1.ConfigMapList, ownerLabelValue string) error {
 
 	tillerNamespace := c.convertOptions.TillerNamespace

--- a/internal/run/convert.go
+++ b/internal/run/convert.go
@@ -165,9 +165,8 @@ func (c *Convert) Execute() error {
 		Context: c.kubeContext,
 	}
 
-	convertErr := convertcmd.Convert(c.convertOptions, kc)
-	if convertErr != nil {
-		return convertErr
+	if err := convertcmd.Convert(c.convertOptions, kc); err != nil {
+		return err
 	}
 
 	clientset, err := clientsetFromFile(c.kubeConfig)
@@ -176,9 +175,8 @@ func (c *Convert) Execute() error {
 	}
 
 	if !c.convertOptions.DeleteRelease {
-		preserveErr := preserveV2(clientset, c.convertOptions)
-		if preserveErr != nil {
-			return preserveErr
+		if err := preserveV2(clientset, c.convertOptions); err != nil {
+			return err
 		}
 	}
 

--- a/internal/run/convert_test.go
+++ b/internal/run/convert_test.go
@@ -11,7 +11,13 @@ import (
 	"helm.sh/helm/v3/pkg/storage"
 	"helm.sh/helm/v3/pkg/storage/driver"
 
+	convertcmd "github.com/helm/helm-2to3/cmd"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 )
 
 func mockActions(t *testing.T) *action.Configuration {
@@ -39,4 +45,149 @@ func TestV3ReleaseFound(t *testing.T) {
 
 	assert.True(t, v3ReleaseFound("myapp", cfg))
 	assert.False(t, v3ReleaseFound("doesnt_exists", cfg))
+}
+
+func TestGetReleaseConfigmaps(t *testing.T) {
+
+	clientset := fake.NewSimpleClientset(
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "myapp.v1",
+				Namespace: "example",
+				Labels: map[string]string{
+					"NAME":    "myapp",
+					"OWNER":   "TILLER",
+					"STATUS":  "DEPLOYED",
+					"VERSION": "1",
+				},
+			},
+		},
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "myapp.v2",
+				Namespace: "example",
+				Labels: map[string]string{
+					"NAME":    "myapp",
+					"OWNER":   "TILLER",
+					"STATUS":  "DEPLOYED",
+					"VERSION": "2",
+				},
+			},
+		},
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "other.v1",
+				Namespace: "example",
+				Labels: map[string]string{
+					"NAME":    "other",
+					"OWNER":   "TILLER",
+					"STATUS":  "DEPLOYED",
+					"VERSION": "1",
+				},
+			},
+		},
+	)
+
+	cmaps, err := getReleaseConfigmaps(clientset, "myapp", "example", "")
+	assert.NoError(t, err)
+	assert.Equal(t, len(cmaps.Items), 2)
+}
+
+func TestPreserveV2(t *testing.T) {
+
+	clientset := fake.NewSimpleClientset(
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "myapp.v1",
+				Namespace: "example",
+				Labels: map[string]string{
+					"NAME":    "myapp",
+					"OWNER":   "TILLER",
+					"STATUS":  "DEPLOYED",
+					"VERSION": "1",
+				},
+			},
+		},
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "myapp.v2",
+				Namespace: "example",
+				Labels: map[string]string{
+					"NAME":    "myapp",
+					"OWNER":   "TILLER",
+					"STATUS":  "DEPLOYED",
+					"VERSION": "2",
+				},
+			},
+		},
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "other.v1",
+				Namespace: "example",
+				Labels: map[string]string{
+					"NAME":    "other",
+					"OWNER":   "TILLER",
+					"STATUS":  "DEPLOYED",
+					"VERSION": "1",
+				},
+			},
+		},
+	)
+
+	clientset.Fake.AddReactor("update", "configmap", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+		configmapList := &corev1.ConfigMapList{
+			Items: []corev1.ConfigMap{
+				corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "myapp.v1",
+						Namespace: "example",
+						Labels: map[string]string{
+							"NAME":    "myapp",
+							"OWNER":   "none",
+							"STATUS":  "DEPLOYED",
+							"VERSION": "1",
+						},
+					},
+				},
+				corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "myapp.v2",
+						Namespace: "example",
+						Labels: map[string]string{
+							"NAME":    "myapp",
+							"OWNER":   "none",
+							"STATUS":  "DEPLOYED",
+							"VERSION": "2",
+						},
+					},
+				},
+			},
+		}
+
+		return true, configmapList, nil
+	})
+
+	opts := convertcmd.ConvertOptions{
+		DeleteRelease:    false,
+		DryRun:           false,
+		ReleaseName:      "myapp",
+		StorageType:      "configmap",
+		TillerNamespace:  "example",
+		TillerOutCluster: false,
+	}
+
+	err := preserveV2(clientset, opts)
+	assert.NoError(t, err)
+
+	myappv1, err := clientset.CoreV1().ConfigMaps("example").Get("myapp.v1", metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, myappv1.Labels["OWNER"], "none")
+
+	myappv2, err := clientset.CoreV1().ConfigMaps("example").Get("myapp.v2", metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, myappv2.Labels["OWNER"], "none")
+
+	other, err := clientset.CoreV1().ConfigMaps("example").Get("other.v1", metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.NotEqual(t, other.Labels["OWNER"], "none")
 }


### PR DESCRIPTION
If DeleteV2Releases is false then the plugin will preserve the v2 releases by removing the tiller ownership label
