### PR TITLE
Fix: new V3 release using default values

### DIFF
--- a/internal/run/convert.go
+++ b/internal/run/convert.go
@@ -66,7 +66,7 @@ func NewConvert(cfg env.Config, kubeConfig string, kubeContext string) *Convert 
 	}
 
 	if cfg.TillerNS == "" {
-		cfg.TillerNS = "kube-system"
+		cfg.TillerNS = cfg.Namespace
 	}
 
 	if cfg.TillerLabel == "" {

--- a/internal/run/convert.go
+++ b/internal/run/convert.go
@@ -145,27 +145,29 @@ func (c *Convert) Execute() error {
 		Context: c.kubeContext,
 	}
 
-	if !c.convertOptions.DeleteRelease {
-		clientset, err := clientsetFromFile(c.kubeConfig)
-		if err != nil {
-			return err
-		}
+	clientset, err := clientsetFromFile(c.kubeConfig)
+	if err != nil {
+		return err
+	}
 
-		configmaps, err := c.getV2ReleaseConfigmaps(clientset)
-		if err != nil {
-			return err
-		}
+	configmaps, err := c.getV2ReleaseConfigmaps(clientset)
+	if err != nil {
+		return err
+	}
 
-		if err := convertcmd.Convert(c.convertOptions, kc); err != nil {
-			return err
-		}
+	if len(configmaps.Items) > 0 {
+		if !c.convertOptions.DeleteRelease {
+			if err := convertcmd.Convert(c.convertOptions, kc); err != nil {
+				return err
+			}
 
-		if err := c.preserveV2ReleaseConfigmaps(clientset, configmaps, "converted-to-helm3"); err != nil {
-			return err
-		}
-	} else {
-		if err := convertcmd.Convert(c.convertOptions, kc); err != nil {
-			return err
+			if err := c.preserveV2ReleaseConfigmaps(clientset, configmaps, "converted-to-helm3"); err != nil {
+				return err
+			}
+		} else {
+			if err := convertcmd.Convert(c.convertOptions, kc); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/internal/run/convert.go
+++ b/internal/run/convert.go
@@ -43,22 +43,34 @@ func clientsetFromFile(path string) (*kubernetes.Clientset, error) {
 	return kubernetes.NewForConfig(clientConfig)
 }
 
+type ConvertCmd interface {
+	ConvertRelease(convertOptions convertcmd.ConvertOptions, kubeConfig common.KubeConfig) error
+}
+
+type ConvertRelease struct{}
+
+func (cr *ConvertRelease) ConvertRelease(convertOptions convertcmd.ConvertOptions, kubeConfig common.KubeConfig) error {
+	return convertcmd.Convert(convertOptions, kubeConfig)
+}
+
 // Convert holds the parameters to run the Convert action
 type Convert struct {
-	namespace      string
-	debug          action.DebugLog
-	kubeConfig     string
-	kubeContext    string
-	convertOptions convertcmd.ConvertOptions
+	namespace         string
+	debug             action.DebugLog
+	kubeConfig        string
+	kubeContext       string
+	convertOptions    convertcmd.ConvertOptions
+	convertReleaseCmd ConvertCmd
 }
 
 // NewConvert initialize Convert by using values from env.Config
 func NewConvert(cfg env.Config, kubeConfig string, kubeContext string) *Convert {
 
 	convert := &Convert{
-		namespace:   cfg.Namespace,
-		kubeConfig:  kubeConfig,
-		kubeContext: kubeContext,
+		namespace:         cfg.Namespace,
+		kubeConfig:        kubeConfig,
+		kubeContext:       kubeContext,
+		convertReleaseCmd: &ConvertRelease{},
 	}
 
 	if cfg.MaxReleaseVersions == 0 {
@@ -122,6 +134,25 @@ func (c *Convert) preserveV2ReleaseConfigmaps(clientset kubernetes.Interface, co
 	return nil
 }
 
+func (c *Convert) doConvert(configmaps *corev1.ConfigMapList, clientset kubernetes.Interface, kc common.KubeConfig) error {
+	if len(configmaps.Items) > 0 {
+		if !c.convertOptions.DeleteRelease {
+			if err := c.convertReleaseCmd.ConvertRelease(c.convertOptions, kc); err != nil {
+				return err
+			}
+
+			if err := c.preserveV2ReleaseConfigmaps(clientset, configmaps, "converted-to-helm3"); err != nil {
+				return err
+			}
+		} else {
+			if err := c.convertReleaseCmd.ConvertRelease(c.convertOptions, kc); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 // Execute runs Convert from 2to3 package
 // If a v2 version doesn't exists then convertcmd.Convert will error
 // If a V3 version exists, we assume that was migrated and the conversion is not run
@@ -155,23 +186,7 @@ func (c *Convert) Execute() error {
 		return err
 	}
 
-	if len(configmaps.Items) > 0 {
-		if !c.convertOptions.DeleteRelease {
-			if err := convertcmd.Convert(c.convertOptions, kc); err != nil {
-				return err
-			}
-
-			if err := c.preserveV2ReleaseConfigmaps(clientset, configmaps, "converted-to-helm3"); err != nil {
-				return err
-			}
-		} else {
-			if err := convertcmd.Convert(c.convertOptions, kc); err != nil {
-				return err
-			}
-		}
-	}
-
-	return nil
+	return c.doConvert(configmaps, clientset, kc)
 }
 
 // Prepare checks required inputs

--- a/internal/run/convert_test.go
+++ b/internal/run/convert_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/mongodb-forks/drone-helm3/internal/env"
 
+	convertcmd "github.com/helm/helm-2to3/cmd"
+	"github.com/helm/helm-2to3/pkg/common"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chartutil"
 	kubefake "helm.sh/helm/v3/pkg/kube/fake"
@@ -31,6 +33,15 @@ func mockActions(t *testing.T) *action.Configuration {
 	return a
 }
 
+type convertCmdMock struct {
+	Called int
+}
+
+func (c *convertCmdMock) ConvertRelease(convertOptions convertcmd.ConvertOptions, kubeConfig common.KubeConfig) error {
+	c.Called++
+	return nil
+}
+
 func TestV3ReleaseFound(t *testing.T) {
 
 	cfg := mockActions(t)
@@ -44,6 +55,13 @@ func TestV3ReleaseFound(t *testing.T) {
 
 	assert.True(t, v3ReleaseFound("myapp", cfg))
 	assert.False(t, v3ReleaseFound("doesnt_exists", cfg))
+}
+
+func clientsetWithNoV2ConfigmapsMock() *fake.Clientset {
+
+	return fake.NewSimpleClientset(
+		&corev1.ConfigMap{},
+	)
 }
 
 func clientsetWithV2ConfigmapsMock() *fake.Clientset {
@@ -191,4 +209,66 @@ func TestPreserveV2ReleaseConfigmaps(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, cm.Labels["OWNER"], test.ownerLabelValue)
 	}
+}
+
+func TestDoConvertWithV2Release(t *testing.T) {
+	c := NewConvert(env.Config{Release: "myapp", TillerNS: "example"}, "", "")
+	clientset := clientsetWithV2ConfigmapsMock()
+	c.convertReleaseCmd = &convertCmdMock{}
+
+	cmaps, err := c.getV2ReleaseConfigmaps(clientset)
+
+	assert.NoError(t, err)
+
+	// common.KubeConfig is not used in our moock of the convertCmd
+	err = c.doConvert(cmaps, clientset, common.KubeConfig{})
+	assert.NoError(t, err)
+	// assert configmaps
+
+	tests := []struct {
+		namespace       string
+		configmapName   string
+		ownerLabelValue string
+	}{
+		{
+			namespace:       "example",
+			configmapName:   "myapp.v1",
+			ownerLabelValue: "converted-to-helm3",
+		},
+		{
+			namespace:       "example",
+			configmapName:   "myapp.v2",
+			ownerLabelValue: "converted-to-helm3",
+		},
+		{
+			namespace:       "example",
+			configmapName:   "other.v1",
+			ownerLabelValue: "TILLER",
+		},
+	}
+
+	for _, test := range tests {
+		cm, err := clientset.CoreV1().ConfigMaps(test.namespace).Get(test.configmapName, metav1.GetOptions{})
+		assert.NoError(t, err)
+		assert.Equal(t, cm.Labels["OWNER"], test.ownerLabelValue)
+	}
+}
+
+func TestDoConvertNewRelease(t *testing.T) {
+	c := NewConvert(env.Config{Release: "myapp", TillerNS: "example"}, "", "")
+	clientset := clientsetWithNoV2ConfigmapsMock()
+
+	releaseMock := &convertCmdMock{}
+
+	c.convertReleaseCmd = releaseMock
+
+	cmaps, err := c.getV2ReleaseConfigmaps(clientset)
+	assert.NoError(t, err)
+	assert.Equal(t, len(cmaps.Items), 0)
+
+	// common.KubeConfig is not used in our moock of the convertCmd
+	err = c.doConvert(cmaps, clientset, common.KubeConfig{})
+	assert.NoError(t, err)
+	// assert that convert was not called, since no v2 releases exist
+	assert.Equal(t, releaseMock.Called, 0)
 }

--- a/internal/run/convert_test.go
+++ b/internal/run/convert_test.go
@@ -88,6 +88,31 @@ func clientsetWithV2ConfigmapsMock() *fake.Clientset {
 	)
 }
 
+func TestTillerNSValue(t *testing.T) {
+
+	tests := []struct {
+		release   string
+		tillerNS  string
+		namespace string
+	}{
+		{
+			release:   "myapp",
+			tillerNS:  "example",
+			namespace: "other",
+		},
+		{
+			release:   "myapp",
+			tillerNS:  "",
+			namespace: "example",
+		},
+	}
+
+	for _, test := range tests {
+		c := NewConvert(env.Config{Release: test.release, TillerNS: test.tillerNS, Namespace: test.namespace}, "", "")
+		assert.Equal(t, c.convertOptions.TillerNamespace, "example")
+	}
+}
+
 func TestGetV2ReleaseConfigmaps(t *testing.T) {
 
 	c := NewConvert(env.Config{Release: "myapp", TillerNS: "example"}, "", "")


### PR DESCRIPTION
**Changes**

- This changes the default value of TillerNS to be the same as the configured "namespace" value.
- I modified the logic to check if running Convert is required by checking if there's at least one Configmap for v2 release, with this the first time is run, it will check in the same namespace, by default, if there are v2 releases and if not will skip conversion entirely.

Here are a set of user stories that explain the reasoning behind the change and the required actions on the user side if required. In all cases, the users will use the following drone step example:

```yaml
- name: deploy
  image: quay.io/mongodb/drone-helm:v3
  settings:
    chart: <CHART>
    chart_version: <CHART_VERSION>
    namespace: <NAMESPACE>
    release: <APP>
    api_server: <API_SERVER>
    kubernetes_token:
      from_secret: <SECRET>
  when:
    event:
    - push
```

**1.** I'm a user that wants to deploy a brand new helm v3 release in the "myns" namespace.

*Before this change*

- User fills up the values on the example template: replaces <NAMESPACE> with "myns"
- The plugin will use the default value for TillerNS that is "kube-system"
- The plugin will verify that there's no V3 release so it will continue with the convert procedure, trying to find v2 releases to migrate
- The plugin will try to fetch Configmaps related to V2 releases in the TillerNS namespace
- The plugin fails as the Service Account that the users can use have no permissions in kube-system
- The user recives an error and the deployment fails

Possible mitigations without the current change

- Disable convert process with: `disable_v2_convert: true`
- Manually set TillerNS value equal to the namespace value

*After this change*

The default value for TillerNS is the same as the configured namespace so there won't be permission errors.
In our case that we have a Tiller service per namespace, having this default value makes more sense and in this way users won't need to specify a deprecated setting (TillerNS), if they are deploying a new V3 release from scratch.

**2.** I'm a cluster admin and want to deploy a new V3 release in the namespace "myadmin" using tiller running in kube-system

*Before this change*

No change from default template values as TillerNS defaults to kube-system

New deployments will still fail because the code runs the Convert method regardless of there being V2 Configmaps or not.

*After this change*

- Disable convert process with: `disable_v2_convert: true`
- Manually set TillerNS value to "kube-system"

