### PR TITLE
Stop using deprecated ioutil package

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -57,6 +57,6 @@ steps:
         - tag
 ---
 kind: signature
-hmac: 062dab517eff06bb593ae991438b25a1237b656247e7b0d0f447e6f8e7f262d1
+hmac: 2666b1d537359a53e31312237bcfa97093e32a6c2d2901dbdf42aa8d6a5fec2e
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -5,7 +5,7 @@ name: default
 
 steps:
   - name: test
-    image: golangci/golangci-lint:v1.48.0-alpine
+    image: golangci/golangci-lint:v1.48.0
     commands:
       - apk update
       - apk add make

--- a/.drone.yml
+++ b/.drone.yml
@@ -7,8 +7,6 @@ steps:
   - name: test
     image: golangci/golangci-lint:v1.48.0
     commands:
-      - apk update
-      - apk add make
       - make test
 
   - name: snyk
@@ -57,6 +55,6 @@ steps:
         - tag
 ---
 kind: signature
-hmac: f48ea034a27872404351c262c66e9406f309b61e79d30beaf75d6fcee6745f18
+hmac: 9f0495f1c141f86da001f111287688c3fb04db192695bdbc3957931019c48aba
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -57,6 +57,6 @@ steps:
         - tag
 ---
 kind: signature
-hmac: 2666b1d537359a53e31312237bcfa97093e32a6c2d2901dbdf42aa8d6a5fec2e
+hmac: f48ea034a27872404351c262c66e9406f309b61e79d30beaf75d6fcee6745f18
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -5,7 +5,7 @@ name: default
 
 steps:
   - name: test
-    image: golangci/golangci-lint:v1.30.0-alpine
+    image: golangci/golangci-lint:v1.48.0-alpine
     commands:
       - apk update
       - apk add make
@@ -19,7 +19,7 @@ steps:
     commands:
       - snyk monitor
     when:
-      event: 
+      event:
         - push
 
   - name: publish_linux_amd64

--- a/build/Dockerfile-test
+++ b/build/Dockerfile-test
@@ -1,4 +1,4 @@
-FROM golangci/golangci-lint:v1.48.0-alpine as cache
+FROM golangci/golangci-lint:v1.48.0 as cache
 ENV GOLANGCI_LINT_CACHE /root/.cache/go-build
 WORKDIR $GOPATH/src/github.com/mongodb-forks/drone-helm3
 

--- a/build/Dockerfile-test
+++ b/build/Dockerfile-test
@@ -1,4 +1,4 @@
-FROM golangci/golangci-lint:v1.30.0-alpine as cache
+FROM golangci/golangci-lint:v1.48.0-alpine as cache
 ENV GOLANGCI_LINT_CACHE /root/.cache/go-build
 WORKDIR $GOPATH/src/github.com/mongodb-forks/drone-helm3
 

--- a/build/Dockerfile-test
+++ b/build/Dockerfile-test
@@ -6,9 +6,6 @@ WORKDIR $GOPATH/src/github.com/mongodb-forks/drone-helm3
 COPY go.mod go.sum ./
 RUN go mod download
 
-# install make
-RUN apk add make
-
 # build cache
 COPY internal internal
 COPY assets assets

--- a/internal/run/convert_test.go
+++ b/internal/run/convert_test.go
@@ -1,9 +1,9 @@
 package run
 
 import (
-	"io/ioutil"
-	"testing"
 	ctx "context"
+	"io"
+	"testing"
 
 	"github.com/mongodb-forks/drone-helm3/internal/env"
 
@@ -25,7 +25,7 @@ import (
 func mockActions(t *testing.T) *action.Configuration {
 	a := &action.Configuration{}
 	a.Releases = storage.Init(driver.NewMemory())
-	a.KubeClient = &kubefake.FailingKubeClient{PrintingKubeClient: kubefake.PrintingKubeClient{Out: ioutil.Discard}}
+	a.KubeClient = &kubefake.FailingKubeClient{PrintingKubeClient: kubefake.PrintingKubeClient{Out: io.Discard}}
 	a.Capabilities = chartutil.DefaultCapabilities
 	a.Log = func(format string, v ...interface{}) {
 		t.Logf(format, v...)

--- a/internal/run/initkube_test.go
+++ b/internal/run/initkube_test.go
@@ -2,7 +2,6 @@ package run
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -73,7 +72,7 @@ namespace: {{ .Namespace }}
 	err = init.Execute()
 	suite.Require().Nil(err)
 
-	conf, err := ioutil.ReadFile(configFile.Name())
+	conf, err := os.ReadFile(configFile.Name())
 	suite.Require().Nil(err)
 
 	want := `
@@ -99,7 +98,7 @@ func (suite *InitKubeTestSuite) TestExecuteGeneratesConfig() {
 	suite.Require().NoError(init.Prepare())
 	suite.Require().NoError(init.Execute())
 
-	contents, err := ioutil.ReadFile(configFile.Name())
+	contents, err := os.ReadFile(configFile.Name())
 	suite.Require().NoError(err)
 
 	// each setting should be reflected in the generated file
@@ -125,7 +124,7 @@ func (suite *InitKubeTestSuite) TestExecuteGeneratesConfig() {
 
 	suite.Require().NoError(init.Prepare())
 	suite.Require().NoError(init.Execute())
-	contents, err = ioutil.ReadFile(configFile.Name())
+	contents, err = os.ReadFile(configFile.Name())
 	suite.Require().NoError(err)
 	suite.Contains(string(contents), "insecure-skip-tls-verify: true")
 
@@ -254,7 +253,7 @@ func (suite *InitKubeTestSuite) TestDebugOutput() {
 }
 
 func tempfile(name, contents string) (*os.File, error) {
-	file, err := ioutil.TempFile("", name)
+	file, err := os.CreateTemp("", name)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/run/repocerts.go
+++ b/internal/run/repocerts.go
@@ -3,7 +3,7 @@ package run
 import (
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/mongodb-forks/drone-helm3/internal/env"
 )
@@ -26,7 +26,7 @@ func newRepoCerts(cfg env.Config) *repoCerts {
 
 func (rc *repoCerts) write() error {
 	if rc.cert != "" {
-		file, err := ioutil.TempFile("", "repo********.cert")
+		file, err := os.CreateTemp("", "repo********.cert")
 		if err != nil {
 			return fmt.Errorf("failed to create certificate file: %w", err)
 		}
@@ -46,7 +46,7 @@ func (rc *repoCerts) write() error {
 	}
 
 	if rc.caCert != "" {
-		file, err := ioutil.TempFile("", "repo********.ca.cert")
+		file, err := os.CreateTemp("", "repo********.ca.cert")
 		if err != nil {
 			return fmt.Errorf("failed to create CA certificate file: %w", err)
 		}

--- a/internal/run/repocerts_test.go
+++ b/internal/run/repocerts_test.go
@@ -2,12 +2,12 @@ package run
 
 import (
 	"fmt"
-	"github.com/mongodb-forks/drone-helm3/internal/env"
-	"github.com/stretchr/testify/suite"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/mongodb-forks/drone-helm3/internal/env"
+	"github.com/stretchr/testify/suite"
 )
 
 type RepoCertsTestSuite struct {
@@ -43,9 +43,9 @@ func (suite *RepoCertsTestSuite) TestWrite() {
 	suite.NotEqual("", rc.certFilename)
 	suite.NotEqual("", rc.caCertFilename)
 
-	cert, err := ioutil.ReadFile(rc.certFilename)
+	cert, err := os.ReadFile(rc.certFilename)
 	suite.Require().NoError(err)
-	caCert, err := ioutil.ReadFile(rc.caCertFilename)
+	caCert, err := os.ReadFile(rc.caCertFilename)
 	suite.Require().NoError(err)
 	suite.Equal("licensed by the State of Oregon to perform repossessions", string(cert))
 	suite.Equal("Oregon State Licensure board", string(caCert))


### PR DESCRIPTION
https://pkg.go.dev/io/ioutil is "Deprecated: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details."