### PR TITLE
Feature check-outdated

### DIFF
--- a/internal/env/config.go
+++ b/internal/env/config.go
@@ -64,6 +64,7 @@ type Config struct {
 	MaxReleaseVersions  int      `split_words:"true"`                 // Pass --release-versions-max option for 2to3 convert command
 	TillerNS            string   `envconfig:"tiller_ns"`              // Tiller namespace (--tiller-ns) for 2to3 convert command
 	TillerLabel         string   `split_words:"true"`                 // Tiller label selector (--label) for 2to3 convert command
+	CheckOutdated       bool     `split_words:"true"`                 // Check and report if chart version is not latest
 
 	Stdout io.Writer `ignored:"true"`
 	Stderr io.Writer `ignored:"true"`

--- a/internal/run/outdated.go
+++ b/internal/run/outdated.go
@@ -1,0 +1,77 @@
+package run
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/mongodb-forks/drone-helm3/internal/env"
+)
+
+type CheckOutdated struct {
+	*config
+	chart        string
+	chartVersion string
+}
+
+func NewCheckOutdated(cfg env.Config) *CheckOutdated {
+	return &CheckOutdated{
+		config:       newConfig(cfg),
+		chart:        cfg.Chart,
+		chartVersion: cfg.ChartVersion,
+	}
+}
+
+func (c *CheckOutdated) Execute() error {
+	latest, err := c.latestVersion(c.globalFlags())
+	if err != nil {
+		return err
+	}
+
+	if c.chartVersion != latest {
+		fmt.Printf("Chart version %s is outdated, latest version is %s\n", c.chartVersion, latest)
+	}
+
+	return nil
+}
+
+func (c *CheckOutdated) Prepare() error {
+	if !validChartString(c.chart) {
+		return fmt.Errorf("invalid chart reference '%s', format must be repo/chartName", c.chart)
+	}
+
+	return nil
+}
+
+func (c *CheckOutdated) latestVersion(globalArgs []string) (string, error) {
+	var latestVersion string
+	args := globalArgs
+	args = append(args, "search", "repo", c.chart, "-o", "json")
+	searchCmd := command(helmBin, args...)
+
+	data, err := searchCmd.Output()
+	if err != nil {
+		return latestVersion, err
+	}
+
+	output := []struct {
+		Name        string
+		Version     string
+		AppVersion  string `json:"app_version"`
+		Description string
+	}{}
+
+	err = json.Unmarshal(data, &output)
+	if err != nil {
+		return latestVersion, err
+	}
+
+	latestVersion = output[0].Version
+
+	return latestVersion, nil
+}
+
+func validChartString(input string) bool {
+	split := strings.SplitN(input, "/", 2)
+	return len(split) == 2
+}


### PR DESCRIPTION
Add a new feature to check if a helm chart is outdated. It can be used as a stand-alone mode or as part of the upgrade command.

The implementation uses the `helm search` command to obtain the latest version from the repo.

## Test locally

It's possible to test locally without requiring a k8s cluster because it's just a check on the repo index.

`docker build -t drone-helm .`
`docker run --rm -e PLUGIN_MODE=outdated -e PLUGIN_CHART=mongodb/web-app -e PLUGIN_CHART_VERSION=1.0.0 -e PLUGIN_ADD_REPOS="mongodb=https://10gen.github.io/helm-charts" drone-helm`
 
## Review

* [ ] Code changes have tests

* [ ] Any config changes are documented:
    * If the change touches _required_ config, there's a corresponding update to `README.md`
    * There's a corresponding update to `docs/parameter_reference.md`
    * There's a pull request to update [the parameter reference in drone-plugin-index](https://github.com/drone/drone-plugin-index/blob/master/content/pelotech/drone-helm3/index.md)

* [ ] Any large changes have been verified by running a Drone job
