### PR TITLE
Add linting flag to helm upgrade step

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ steps:
       KUBE_TOKEN:
         from_secret: kubernetes_token
 ```
-**Note** that the `lint` settings field show in the example above defaults to `false`.
 
 ### Convert
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ steps:
     settings:
       mode: upgrade
       chart: ./
+      lint: true
       release: my-project
       # disable_v2_conversion: true
     environment:
@@ -45,6 +46,7 @@ steps:
       KUBE_TOKEN:
         from_secret: kubernetes_token
 ```
+**NOTE:** The `lint` settings field provided in the example above, if omitted is defaulted to `false`.
 
 ### Convert
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ steps:
       KUBE_TOKEN:
         from_secret: kubernetes_token
 ```
-**NOTE:** The `lint` settings field provided in the example above, if omitted is defaulted to `false`.
+**Note** that the `lint` settings field show in the example above defaults to `false`.
 
 ### Convert
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ steps:
     settings:
       mode: upgrade
       chart: ./
-      lint: true
+      lint: false
       release: my-project
       # disable_v2_conversion: true
     environment:

--- a/internal/env/config.go
+++ b/internal/env/config.go
@@ -64,6 +64,7 @@ type Config struct {
 	MaxReleaseVersions  int      `split_words:"true"`                 // Pass --release-versions-max option for 2to3 convert command
 	TillerNS            string   `envconfig:"tiller_ns"`              // Tiller namespace (--tiller-ns) for 2to3 convert command
 	TillerLabel         string   `split_words:"true"`                 // Tiller label selector (--label) for 2to3 convert command
+	Lint                bool     ``                                   // Tell the upgrade plan to run a lint action before upgrading
 
 	Stdout io.Writer `ignored:"true"`
 	Stderr io.Writer `ignored:"true"`

--- a/internal/helm/plan.go
+++ b/internal/helm/plan.go
@@ -116,6 +116,10 @@ var upgrade = func(cfg env.Config) []Step {
 		steps = append(steps, run.NewDepUpdate(cfg))
 	}
 
+	if cfg.Lint {
+		steps = append(steps, lint(cfg)...)
+	}
+
 	steps = append(steps, run.NewUpgrade(cfg))
 
 	return steps

--- a/internal/helm/plan.go
+++ b/internal/helm/plan.go
@@ -117,7 +117,7 @@ var upgrade = func(cfg env.Config) []Step {
 	}
 
 	if cfg.Lint {
-		steps = append(steps, lint(cfg)...)
+		steps = append(steps, run.NewLint(cfg))
 	}
 
 	steps = append(steps, run.NewUpgrade(cfg))

--- a/internal/helm/plan_test.go
+++ b/internal/helm/plan_test.go
@@ -172,7 +172,7 @@ func (suite *PlanTestSuite) TestUpgradeWithLint() {
 
 func (suite *PlanTestSuite) TestUpgradeWithoutLint() {
 	steps := upgrade(env.Config{Lint: false})
-	suite.Require().Equal(3, len(steps), "upgrade should return 4 steps")
+	suite.Require().Equal(3, len(steps), "upgrade should return 3 steps")
 	suite.IsType(&run.InitKube{}, steps[0])
 	suite.IsType(&run.Convert{}, steps[1])
 	suite.IsType(&run.Upgrade{}, steps[2])

--- a/internal/helm/plan_test.go
+++ b/internal/helm/plan_test.go
@@ -161,6 +161,23 @@ func (suite *PlanTestSuite) TestUpgradeWithoutConvert() {
 	suite.IsType(&run.Upgrade{}, steps[1])
 }
 
+func (suite *PlanTestSuite) TestUpgradeWithLint() {
+	steps := upgrade(env.Config{Lint: true})
+	suite.Require().Equal(4, len(steps), "upgrade should return 4 steps")
+	suite.IsType(&run.InitKube{}, steps[0])
+	suite.IsType(&run.Convert{}, steps[1])
+	suite.IsType(&run.Lint{}, steps[2])
+	suite.IsType(&run.Upgrade{}, steps[3])
+}
+
+func (suite *PlanTestSuite) TestUpgradeWithoutLint() {
+	steps := upgrade(env.Config{Lint: false})
+	suite.Require().Equal(3, len(steps), "upgrade should return 4 steps")
+	suite.IsType(&run.InitKube{}, steps[0])
+	suite.IsType(&run.Convert{}, steps[1])
+	suite.IsType(&run.Upgrade{}, steps[2])
+}
+
 func (suite *PlanTestSuite) TestUninstall() {
 	steps := uninstall(env.Config{})
 	suite.Require().Equal(2, len(steps), "uninstall should return 2 steps")


### PR DESCRIPTION
## Description
In this PR I've added changes to the configuration of the helm plugin step `upgrade` when used in drone. I've added a `lint` flag to the configuration spec. This flag or struct variable is then only read by the `upgrade` action. This makes it possible to run linting as part of the `install/upgrade` step.

## Testing
So far I've only tried testing these changes with unit tests but I don't feel that they are sufficient to test that this solution really works. Therefore I haven't included any testing execution steps yet.
Having a local drone setup would be a good candidate for testing these changes. So far I haven't tried this yet and I'll make time for it to try it out.
