### PR TITLE
Revert "Add linting flag to helm upgrade step"

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ steps:
     settings:
       mode: upgrade
       chart: ./
-      lint: false
       release: my-project
       # disable_v2_conversion: true
     environment:

--- a/internal/env/config.go
+++ b/internal/env/config.go
@@ -64,7 +64,6 @@ type Config struct {
 	MaxReleaseVersions  int      `split_words:"true"`                 // Pass --release-versions-max option for 2to3 convert command
 	TillerNS            string   `envconfig:"tiller_ns"`              // Tiller namespace (--tiller-ns) for 2to3 convert command
 	TillerLabel         string   `split_words:"true"`                 // Tiller label selector (--label) for 2to3 convert command
-	Lint                bool     ``                                   // Tell the upgrade plan to run a lint action before upgrading
 
 	Stdout io.Writer `ignored:"true"`
 	Stderr io.Writer `ignored:"true"`

--- a/internal/helm/plan.go
+++ b/internal/helm/plan.go
@@ -116,10 +116,6 @@ var upgrade = func(cfg env.Config) []Step {
 		steps = append(steps, run.NewDepUpdate(cfg))
 	}
 
-	if cfg.Lint {
-		steps = append(steps, run.NewLint(cfg))
-	}
-
 	steps = append(steps, run.NewUpgrade(cfg))
 
 	return steps

--- a/internal/helm/plan_test.go
+++ b/internal/helm/plan_test.go
@@ -161,23 +161,6 @@ func (suite *PlanTestSuite) TestUpgradeWithoutConvert() {
 	suite.IsType(&run.Upgrade{}, steps[1])
 }
 
-func (suite *PlanTestSuite) TestUpgradeWithLint() {
-	steps := upgrade(env.Config{Lint: true})
-	suite.Require().Equal(4, len(steps), "upgrade should return 4 steps")
-	suite.IsType(&run.InitKube{}, steps[0])
-	suite.IsType(&run.Convert{}, steps[1])
-	suite.IsType(&run.Lint{}, steps[2])
-	suite.IsType(&run.Upgrade{}, steps[3])
-}
-
-func (suite *PlanTestSuite) TestUpgradeWithoutLint() {
-	steps := upgrade(env.Config{Lint: false})
-	suite.Require().Equal(3, len(steps), "upgrade should return 3 steps")
-	suite.IsType(&run.InitKube{}, steps[0])
-	suite.IsType(&run.Convert{}, steps[1])
-	suite.IsType(&run.Upgrade{}, steps[2])
-}
-
 func (suite *PlanTestSuite) TestUninstall() {
 	steps := uninstall(env.Config{})
 	suite.Require().Equal(2, len(steps), "uninstall should return 2 steps")


### PR DESCRIPTION
Reverts mongodb-forks/drone-helm3#19

There was a finding that the `lint` flag in the upgrade mode wont work.
The input for helm lint is different than the input for helm upgrade, the former expects a local path with the source of the helm chart and the latter expects a helm “package” from a helm repo.