### PR TITLE
Dockerfile dependencies update and multi-arch support

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -25,7 +25,7 @@ steps:
         from_secret: CACHE_S3_SECRET_KEY
 
   - name: test
-    image: golangci/golangci-lint:v1.48.0
+    image: golangci/golangci-lint:v1.56.0
     environment:
       GOCACHE: /drone/src/gocache/
       GOLANGCI_LINT_CACHE: /drone/src/golangcilintcache/
@@ -39,7 +39,7 @@ steps:
       - restore
 
   - name: snyk
-    image: snyk/snyk:golang-1.14
+    image: snyk/snyk:golang-1.21
     environment:
       SNYK_TOKEN:
         from_secret: snyk_token
@@ -116,6 +116,6 @@ steps:
 
 ---
 kind: signature
-hmac: 636cd0f3fce3658b022d65cd68db783196a38d212fe539e486fea903aea80c97
+hmac: f4dbe8e8a3a36d5468cef7c9e391a89fcbb7cc231d34737ee32ff6496cf0e9a3
 
 ...

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 RUN CGO_ENABLED=0 go build -o /go/bin/drone-helm ./cmd/drone-helm
 
 # --- Copy the cli to an image with helm already installed ---
-FROM alpine/helm:3.8.1
+FROM alpine/helm:3.13.3
 
 COPY --from=build /go/bin/drone-helm /bin/
 COPY --chmod=600 ./assets/kubeconfig.tpl /root/.kube/config.tpl

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY . .
 RUN CGO_ENABLED=0 go build -o /go/bin/app ./cmd/drone-helm
 
 # --- Copy the cli to an image with helm already installed ---
-FROM alpine/helm:3.13.3
+FROM alpine/helm:3.8.1
 
 COPY --chmod=600 ./assets/kubeconfig.tpl /root/.kube/config.tpl
 COPY --from=build /go/bin/app /

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM golang:1.21 as build
 
-ARG PLUGIN_TYPE="drone"
 WORKDIR /go/src/app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,12 @@ WORKDIR /go/src/app
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN CGO_ENABLED=0 go build -o /go/bin/drone-helm ./cmd/drone-helm
+RUN CGO_ENABLED=0 go build -o /go/bin/app ./cmd/drone-helm
 
 # --- Copy the cli to an image with helm already installed ---
 FROM alpine/helm:3.13.3
 
-COPY --from=build /go/bin/drone-helm /bin/
 COPY --chmod=600 ./assets/kubeconfig.tpl /root/.kube/config.tpl
+COPY --from=build /go/bin/app /
 
-ENTRYPOINT [ "/bin/drone-helm" ]
+ENTRYPOINT [ "/app" ]

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mongodb-forks/drone-helm3
 
-go 1.18
+go 1.21
 
 require (
 	github.com/golang/mock v1.6.0


### PR DESCRIPTION
## Goals and expectations

- To remove the hardcoded amd64 compilation of the go pkg so the image can be compiled for arm64 too
- To update the Go version

## Changes

Update Dockerfile

- Bump golang version
- Bump helm version
- Remove hardcoded ARCH in go build
- Minor cosmetic changes

Both the golang and helm images are multi-arch so they will build, or package, the proper binary when running in arm64 or amd64

I'm thinking on fully removing the drone.yml file as the build and publish will happen out of this repo.

## Local testing

Run the drone-helm3 plugin locally with podman, or docker, to install a helm chart.

```sh
MYAPISERVER="someurl"
MYNAMESPACE="somenamespace"
MYTOKEN="kubetoken"

podman build -t drone-helm3:multi-arch
podman run --rm -e PLUGIN_MODE=upgrade -ePLUGIN_ADD_REPOS="bitnami=https://charts.bitnami.com/bitnami" -e PLUGIN_CHART=bitnami/nginx -ePLUGIN_KUBE_API_SERVER=${MYAPISERVER} -ePLUGIN_KUBE_TOKEN=${MYTOKEN} -ePLUGIN_NAMESPACE=${MYNAMESPACE} -ePLUGIN_RELEASE=drone-nginx-example localhost/drone-helm3:multi-arch
```


