### PR TITLE
Update initkube.go

### DIFF
--- a/internal/run/initkube.go
+++ b/internal/run/initkube.go
@@ -87,7 +87,7 @@ func (i *InitKube) Prepare() error {
 		fmt.Fprintf(i.stderr, "kubeconfig file at %s\n", i.configFilename)
 	}
 
-	i.configFile, err = os.Create(i.configFilename)
+	i.configFile, err = os.OpenFile(i.configFilename, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return fmt.Errorf("could not open kubeconfig file for writing: %w", err)
 	}


### PR DESCRIPTION
This will remove "WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /root/.kube/config" warning.
